### PR TITLE
fix read_lines not using its argument + give explicit return value

### DIFF
--- a/context.R
+++ b/context.R
@@ -1,9 +1,9 @@
 test_env <- new.env()
 
-read_lines <- function(file) {
-    con <- file(student_code, "r")
+read_lines <- function(filename) {
+    con <- file(filename, "r")
     on.exit(close(con))
-    lines <- readLines(con, warn = FALSE)
+    readLines(con, warn = FALSE)
 }
 
 context <- function(testcases={}, preExec={}) {


### PR DESCRIPTION
The read_lines function was not using its argument -> fixed.
Give the read_lines function a parameter that has a different name than a function in the body of read_lines to avoid confusion.
Give the read_lines function an explicit return value.