### PR TITLE
fix bug in testEqual function

### DIFF
--- a/test.R
+++ b/test.R
@@ -11,7 +11,7 @@ testEqual <- function(description, generated, expected, comparator = NULL, ...) 
                 if (is.null(comparator)) {
                     equal <- isTRUE(all.equal(generated_val, expected_val, ...))
                 } else {
-                    equal <- comparator(generated, expected, ...)
+                    equal <- comparator(generated_val, expected_val, ...)
                 }
 
                 if (equal) {


### PR DESCRIPTION
When specifying a comparator to the testEqual function, it passes the `generated' function to the comparator instead of the generated_val. Causing the following error when using the setequal() comparator.

cannot coerce type 'closure' to vector of type 'any' 
