### PR TITLE
quick fix for environ of preExec

### DIFF
--- a/context.R
+++ b/context.R
@@ -19,11 +19,12 @@ context <- function(testcases={}, preExec={}) {
     tryCatch(
         withCallingHandlers(
             {
-                eval(preExec, envir = test_env$clean_env)
+                eval(substitute(preExec), envir = test_env$clean_env)
                 # We don't use source, because otherwise syntax errors leak the location of the student code
                 assign(".Last.value",
                        eval(parse(text = read_lines(student_code)), envir = test_env$clean_env),
                        envir = test_env$clean_env)
+                eval(preExec)
                 eval(testcases)
             },
             warning = function(w) {


### PR DESCRIPTION
Solves the issue that the code/objects in preExec were not available in the student code environment. With this fix, preExec code/objects are now available in both student and test environments.

Still, the use of environments in the judge could be imroved by making nested environments (see suggestion below), so that preExec is not run twice as in the current patch. Tbd with @charvp 

Suggestion:
```{r}
testEnvir <- new.env() # parent envir for all exercise code
studentEnvir <- new.env(parent=testEnvir) # child envir for student code
evalEnvir <- new.env(parent=testEnvir) # child envir for the test code

context <- function(testcases={},preExec={}){
    eval(substitute(preExec),envir=testEnvir) # make preExec available to both student and testcode
    assign(".Last.value",
           eval(parse(text=read_lines("test.R")),envir=studentEnvir),
           envir=studentEnvir)
    eval(testcases,envir=evalEnvir) # run the testcode in its own envir
}

```
