### PR TITLE
fix for environment of preExec

### DIFF
--- a/context.R
+++ b/context.R
@@ -1,5 +1,3 @@
-test_env <- new.env()
-
 read_lines <- function(filename) {
     con <- file(filename, "r")
     on.exit(close(con))
@@ -15,16 +13,21 @@ context <- function(testcases={}, preExec={}) {
         }
     })
 
-    test_env$clean_env <- new.env(parent = globalenv())
+    # Create the testEnvir and child envirs
+    # double assignment operator so that these exist outside the context function
+    testEnvir <<- new.env(globalenv())
+    studentEnvir <<- new.env(parent=testEnvir)
+    teacherEnvir <<- new.env(parent=testEnvir)
+
     tryCatch(
         withCallingHandlers(
             {
-                eval(preExec, envir = test_env$clean_env)
+                eval(substitute(preExec), envir = testEnvir)
                 # We don't use source, because otherwise syntax errors leak the location of the student code
                 assign(".Last.value",
-                       eval(parse(text = read_lines(student_code)), envir = test_env$clean_env),
-                       envir = test_env$clean_env)
-                eval(testcases)
+                       eval(parse(text = read_lines(student_code)), envir = studentEnvir),
+                       envir = studentEnvir)
+                eval(testcases, envir = teacherEnvir)
             },
             warning = function(w) {
                 get_reporter()$add_message(paste("Warning while evaluating context: ", conditionMessage(w), sep = ''))

--- a/test.R
+++ b/test.R
@@ -5,7 +5,7 @@ testEqual <- function(description, generated, expected, comparator = NULL, ...) 
         withCallingHandlers(
             {
                 expected_val <- expected
-                generated_val <- generated(test_env$clean_env)
+                generated_val <- generated(studentEnvir)
 
                 equal <- FALSE
                 if (is.null(comparator)) {
@@ -42,7 +42,7 @@ testIdentical <- function(description, generated, expected, ...) {
         withCallingHandlers(
             {
                 expected_val <- expected
-                generated_val <- generated(test_env$clean_env)
+                generated_val <- generated(studentEnvir)
 
                 equal <- isTRUE(identical(generated_val, expected_val, ...))
 
@@ -72,7 +72,7 @@ testImage <- function(generate, failIfAbsent = TRUE) {
     tryCatch(
         withCallingHandlers(
             {
-                generate(test_env$clean_env)
+                generate(studentEnvir)
             },
             warning = function(w) {
                 get_reporter()$add_message(paste("Warning while evaluating image for testcase: ", conditionMessage(w), sep = ''))

--- a/testcase.R
+++ b/testcase.R
@@ -9,7 +9,8 @@ testcase <- function(description = NULL, tests={}) {
 
     tryCatch(
         {
-            eval(tests)
+            # Run the tests in the teacherEnvir
+            eval(substitute(tests), envir=teacherEnvir)
         },
         error = function(e) {
             get_reporter()$add_message(paste("Error while evaluating testcase: ", conditionMessage(e), sep = ''))


### PR DESCRIPTION
Solves the issue that the code/objects in preExec were not available in the student code environment. With this fix, preExec code/objects are now available in both student and test (teacher) environments.

The fix makes the environments where the student and testcode is run more explicit in the code, defines nested environments where `preExec` code is run in the top environment and makes use of the `substitute()` function as is required when using the `eval()` function.

This is an improved fix compared to my previoux, cancelled PR: https://github.com/dodona-edu/judge-r/pull/14