### PR TITLE
Document and improve the testDF function

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ The `testIdentical` function use the `base::identical` function internally to de
 
 The `testImage` function is a special case, since it won't actually add a test to the output. Instead, it only expects one argument: a function taking the environment, that will generate an image when called. By default, this function will make the output wrong if the expected image wasn't generated. This behaviour can be changed by setting the optional `failIfAbsent` parameter to `FALSE`.
 
+### `testDF`
+
+The `testDF` function can be used to test the equality of dataframes. It uses `dplyr::all_equal` under the hood (with the `ignore_col_order` and `ignore_row_order` options set to `TRUE` by default). All arguments that the `dplyr::all_equal` function accepts can be passed to this function as well. Again, a custom `comparator` can be passed if necessary. The feedback in Dodona will show the first five rows of the dataframe(s).
+
 #### `testFunctionUsedInVar`
 
 The `testFunctionUsedInVar` function is testfunction to test if a certain function is used in the assignation of a certain variable in the student code. It can also detect indirect assignations (e.g. `a <- b <- mean(1)` will return correct if the testfunction `testFunctionUsedInVar("mean", "a")` is used). As you can see in the example the function takes 2 parameters (1. The name of the function you want to test for (string), 2. The name of the variable for which the function is used in it's assignment (string))


### PR DESCRIPTION
The output will no longer show up in HTML tables, but will be shown in the Dodona diff. We still only use the `head` of the dataframes, but a message was added to explain it to the students. I also removed the `ignore_col/row_order` arguments, since TRUE is the default for those arguments in dplyr and the way it was implemented, they couldn't be passed to the custom comparator.