### PR TITLE
Test gg plot extend

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The `testDF` function can be used to test the equality of dataframes. It uses `d
 
 #### `testGGPlot`
 
-The `testGGPlot` function can be used to test the equality of `GGPlot`s. Aside from the usual `description`, `generated` and `expected` arguments it has three optional arguments: `test_data`, `test_aes` and `test_geom`. All of them are true by default and are used to determine whether that particular layer should be tested or not.
+The `testGGPlot` function can be used to test the equality of `GGPlot`s. Aside from the usual `description`, `generated` and `expected` arguments it has 5 optional arguments: `test_data`, `test_aes`, `test_geom`, `test_label` and `test_scale`. These are used to determine whether that particular layer should be tested or not. `test_data`, `test_aes` and `test_geom` are true by default, `test_label` and `test_scale` are false by default.
 
 #### `testFunctionUsed`
 

--- a/test.R
+++ b/test.R
@@ -74,7 +74,7 @@ testDF <- function(description, generated, expected, comparator = NULL, ...) {
     )
 }
 
-testGGPlot <- function(description, generated, expected, test_data = TRUE, test_aes = TRUE, test_geom = TRUE) {
+testGGPlot <- function(description, generated, expected, test_data = TRUE, test_aes = TRUE, test_geom = TRUE, test_label = FALSE, test_scale = FALSE) {
     get_reporter()$start_test("", description)
 
     tryCatch(
@@ -97,6 +97,16 @@ testGGPlot <- function(description, generated, expected, test_data = TRUE, test_
                      }
                  }
 
+                 if (test_label) {
+                     expected_labels <- expected_gg$labels
+                     generated_labels <- generated_gg$labels
+                     if (!isTRUE(all.equal(expected_labels$x, generated_labels$x)) |
+                         !isTRUE(all.equal(expected_labels$y, generated_labels$y))){
+                         feedback <- "Did you specify the correct labels?"
+                         equal <- FALSE
+                     }
+                 }
+
                  # Dont execute if a difference was already found in one of the previous layers
                  if (test_aes && equal) {
                      test_aes_result <- test_aes_layer(expected_gg$mapping, generated_gg$mapping)
@@ -110,6 +120,23 @@ testGGPlot <- function(description, generated, expected, test_data = TRUE, test_
                      test_geom_result <- test_geom_layer(expected_gg$layers, generated_gg$layers)
                      if (!test_geom_result$equal) {
                          feedback <- test_geom_result$feedback
+                         equal <- FALSE
+                     }
+                 }
+                 
+                 # Building the plot is required to correctly evaluate the panel scales using all.equal
+                 expected_build <- ggplot_build(expected_gg)
+                 generated_build <- ggplot_build(generated_gg)
+
+                 if (test_scale && equal) {
+                     expected_scale_x <- expected_build$layout$panel_scales_x
+                     expected_scale_y <- expected_build$layout$panel_scales_y
+                     generated_scale_x <- generated_build$layout$panel_scales_x
+                     generated_scale_y <- generated_build$layout$panel_scales_y
+
+                     if (!isTRUE(all.equal(expected_scale_x, generated_scale_x)) |
+                         !isTRUE(all.equal(expected_scale_y, generated_scale_y))){
+                         feedback <- "Did you specify the correct scales?"
                          equal <- FALSE
                      }
                  }

--- a/test.R
+++ b/test.R
@@ -123,19 +123,11 @@ testGGPlot <- function(description, generated, expected, test_data = TRUE, test_
                          equal <- FALSE
                      }
                  }
-                 
-                 # Building the plot is required to correctly evaluate the panel scales using all.equal
-                 expected_build <- ggplot_build(expected_gg)
-                 generated_build <- ggplot_build(generated_gg)
 
                  if (test_scale && equal) {
-                     expected_scale_x <- expected_build$layout$panel_scales_x
-                     expected_scale_y <- expected_build$layout$panel_scales_y
-                     generated_scale_x <- generated_build$layout$panel_scales_x
-                     generated_scale_y <- generated_build$layout$panel_scales_y
-
-                     if (!isTRUE(all.equal(expected_scale_x, generated_scale_x)) |
-                         !isTRUE(all.equal(expected_scale_y, generated_scale_y))){
+                     expected_scale <- expected_gg$scales$scales
+                     generated_scale <- generated_gg$scales$scales
+                     if (!isTRUE(all.equal(expected_scale, generated_scale))) {
                          feedback <- "Did you specify the correct scales?"
                          equal <- FALSE
                      }

--- a/utils-plot.R
+++ b/utils-plot.R
@@ -2,7 +2,7 @@
 
 test_data_layer <- function(sol_data, stud_data) {
     feedback <- "You did not add the correct data."
-    list('equal' = isTRUE(all.equal(sol_data, stud_data, check.attributes = FALSE)), 'feedback' = feedback)
+    list('equal' = isTRUE(all.equal(sol_data, stud_data)), 'feedback' = feedback)
 }
 
 test_aes_layer <- function(sol_mapping, stud_mapping) {


### PR DESCRIPTION
I added 2 optional checks to testGGPlot to check if the x and y axis labels are correct and if the scales are correct. I also removed the check.attributes option from test_data_layer since this causes some changes to the input data frame (such as factor level reordering) to not be evaluated correctly.