### PR TITLE
Fix libraries loaded by test code being available in the student environment

### DIFF
--- a/run
+++ b/run
@@ -1,6 +1,10 @@
 #!/usr/bin/env Rscript
 
 invisible(evalq({
+    # We need to save the parent of the global environment before we load any
+    # libraries. See context.R for a more extensive explanation.
+    starting_parent_env <- parent.env(.GlobalEnv)
+
     library('jsonlite')
     library('base64enc')
     library('R6')


### PR DESCRIPTION
The way I did this (which is not trivial at all) is explained in the (new) comment at the top of context.R. One element which I'm not entirely happy with is that I had to duplicate the fix over both context functions. There were problems related to `preExec` which I was not able to fix however. I will create an issue to look into deduplicating the execution of the student code again at a later date.