### PR TITLE
ggplot-testing: facet-layering-testing added + improved flexibility added in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ The `testDF` function can be used to test the equality of dataframes. It uses `d
 
 #### `testGGPlot`
 
-The `testGGPlot` function can be used to test the equality of `GGPlot`s. Aside from the usual `description`, `generated` and `expected` arguments it has some optional arguments: 
-- `show_expected = TRUE` A logical value indicating whether the solution plot should be shown to the student if the `testGGPlot` function determines the solution to be incorrect. If set to `FALSE` the student won't be able to compare his/her ggplot with the solution which could make an exercise really hard to solve. Please handle with care.
+The `testGGPlot` function can be used to test the equality of `GGPlot`s. Aside from the usual `description`, `generated` and `expected` arguments it has some optional arguments:
+- `show_expected = TRUE` A logical value indicating whether the solution plot should be shown to the student if the `testGGPlot` function determines the solution to be incorrect. If set to `FALSE` the student won't be able to compare their plot with the solution which could make an exercise really hard to solve. Please handle with care.
 - `test_data = TRUE` A logical value indicating whether the input data to the `ggplot` function should be verified. This test will succeed if all columns from the solution have a corresponding column in the given input with the same column name and data.
 - `test_geom = TRUE` A logical value indicating whether the geometric layers should be checked. For each layer the parameters and aesthetics are verified. This test method also takes into account the default aesthetics set in the `ggplot` function itself.
 - `test_facet = TRUE` A logical value indicating whether the facet layer should be tested. This test supports `facet_grid` and `facet_wrap` layers and can compare them to one another (e.g. a `facet_grid` with only 1 row/column can be equal to a `facet_wrap` and vice versa).

--- a/README.md
+++ b/README.md
@@ -88,7 +88,15 @@ The `testDF` function can be used to test the equality of dataframes. It uses `d
 
 #### `testGGPlot`
 
-The `testGGPlot` function can be used to test the equality of `GGPlot`s. Aside from the usual `description`, `generated` and `expected` arguments it has 5 optional arguments: `test_data`, `test_aes`, `test_geom`, `test_label` and `test_scale`. These are used to determine whether that particular layer should be tested or not. `test_data`, `test_aes` and `test_geom` are true by default, `test_label` and `test_scale` are false by default.
+The `testGGPlot` function can be used to test the equality of `GGPlot`s. Aside from the usual `description`, `generated` and `expected` arguments it has some optional arguments: 
+- `show_expected = TRUE` A logical value indicating whether the solution plot should be showed to the student if the testGGPlot function failes.
+- `test_data = TRUE` A logical value indicating whether the input data to the ggplot function should be verified. This test will succeed if all columns from the solution have a corresponding column in the given input with the same column-name and data.
+- `test_geom = TRUE` A logical value indicating whether the geometric layers should be checked. For each layer the parameters and aesthetics are verified. This test method also takes in to account the default aesthetics set in the ggplot function itself.
+- `test_facet = TRUE` A logical value indicating whether the facet layer should be tested. This test supports `faced_grid` and `faced_wrap` layers and can compare them to one another. (e.g. A faced_grid with only 1 row/column can be equal to a faced_wrapand, visa versa)
+- `test_label = FALSE` A logical value indicating whether the label layers should be tested.
+- `test_scale = FALSE` A logical value indicating whether the scale of the axis should be tested.
+
+> Note: Because we want the testing of the ggplot to be as flexible as possible the testfunctions are all made in a way that the given solution ggplot is the plot that defines the minimal requirements for the student plot. When writing exercises this is a very important aspect to keep in mind. As an example we dont recommend testing to the ggplots where you defined parameters to be used in geometric layers in the ggplot function itself. This because the testfunction would test for these parameters in every geometric layer in the students ggplot even when they are not used.
 
 #### `testFunctionUsed`
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The `testDF` function can be used to test the equality of dataframes. It uses `d
 #### `testGGPlot`
 
 The `testGGPlot` function can be used to test the equality of `GGPlot`s. Aside from the usual `description`, `generated` and `expected` arguments it has some optional arguments: 
-- `show_expected = TRUE` A logical value indicating whether the solution plot should be shown to the student if the `testGGPlot` function determines the solution to be incorrect.
+- `show_expected = TRUE` A logical value indicating whether the solution plot should be shown to the student if the `testGGPlot` function determines the solution to be incorrect. If set to `FALSE` the student won't be able to compare his/her ggplot with the solution which could make an exercise really hard to solve. Please handle with care.
 - `test_data = TRUE` A logical value indicating whether the input data to the `ggplot` function should be verified. This test will succeed if all columns from the solution have a corresponding column in the given input with the same column name and data.
 - `test_geom = TRUE` A logical value indicating whether the geometric layers should be checked. For each layer the parameters and aesthetics are verified. This test method also takes into account the default aesthetics set in the `ggplot` function itself.
 - `test_facet = TRUE` A logical value indicating whether the facet layer should be tested. This test supports `facet_grid` and `facet_wrap` layers and can compare them to one another (e.g. a `facet_grid` with only 1 row/column can be equal to a `facet_wrap` and vice versa).

--- a/context.R
+++ b/context.R
@@ -84,7 +84,7 @@ contextWithRmd <- function(testcases={}, preExec={}) {
                  tryCatch({
                      eval(substitute(preExec), envir = test_env$clean_env)
                      # We don't use source, because otherwise syntax errors leak the location of the student code
-                     test_env$parsed_code <- parse(text = knitr::purl(text = read_lines(student_code)))
+                     test_env$parsed_code <- parse(text = knitr::purl(text = read_lines(student_code), quiet=TRUE))
                      assign("evaluationResult", eval(test_env$parsed_code, envir = test_env$clean_env), envir = test_env$clean_env)
                  }, finally = {
                      parent.env(.GlobalEnv) <- old_parent

--- a/test.R
+++ b/test.R
@@ -84,7 +84,14 @@ testDF <- function(description, generated, expected, comparator = NULL, ...) {
     )
 }
 
-testGGPlot <- function(description, generated, expected, test_data = TRUE, test_aes = TRUE, test_geom = TRUE, test_label = FALSE, test_scale = FALSE) {
+testGGPlot <- function(description, generated, expected, show_expected = TRUE,
+                        test_data = TRUE, 
+                        test_geom = TRUE, 
+                        test_facet = TRUE,
+                        test_label = FALSE, 
+                        test_scale = FALSE
+                        ) {
+
     get_reporter()$start_test("", description)
 
     tryCatch(
@@ -117,17 +124,16 @@ testGGPlot <- function(description, generated, expected, test_data = TRUE, test_
                      }
                  }
 
-                 # Dont execute if a difference was already found in one of the previous layers
-                 if (test_aes && equal) {
-                     test_aes_result <- test_aes_layer(expected_gg$mapping, generated_gg$mapping)
-                     if (!test_aes_result$equal) {
-                         feedback <- test_aes_result$feedback
+                 if (test_facet && equal) {
+                     test_facet_result <- test_facet_layer(expected_gg$facet, generated_gg$facet)
+                     if (!test_facet_result$equal) {
+                         feedback <- test_facet_result$feedback
                          equal <- FALSE
                      }
                  }
 
                  if (test_geom && equal) {
-                     test_geom_result <- test_geom_layer(expected_gg$layers, generated_gg$layers)
+                     test_geom_result <- test_geom_layer(expected_gg, generated_gg)
                      if (!test_geom_result$equal) {
                          feedback <- test_geom_result$feedback
                          equal <- FALSE
@@ -150,8 +156,10 @@ testGGPlot <- function(description, generated, expected, test_data = TRUE, test_
                  } else {
                      image_generated <- base64enc::base64encode(tf_generated)
                      get_reporter()$add_message(paste("<img style=\"max-width:100%; width:450px;\" src=\"data:image/png;base64,", image_generated, "\"/>", sep=''), type = "html")
-                     image_expected <- base64enc::base64encode(tf_expected)
-                     get_reporter()$add_message(paste("<img style=\"max-width:100%; width:450px;\" src=\"data:image/png;base64,", image_expected, "\"/>", sep=''), type = "html")
+                     if(show_expected){
+                        image_expected <- base64enc::base64encode(tf_expected)
+                        get_reporter()$add_message(paste("<img style=\"max-width:100%; width:450px;\" src=\"data:image/png;base64,", image_expected, "\"/>", sep=''), type = "html")
+                     }
                      get_reporter()$add_message(feedback)
                      get_reporter()$end_test("", "wrong")
                  }

--- a/utils-plot.R
+++ b/utils-plot.R
@@ -28,10 +28,6 @@ test_facet_layer <- function(sol_facet, stud_facet) {
         if (stud_type == "FacetGrid") {
             stud_cols <- names(stud_facet$params$cols)
             stud_rows <- names(stud_facet$params$rows)
-            print(paste("1.1", length(intersect(sol_cols, stud_cols))))
-            print(paste("1.2", length(sol_cols)))
-            print(paste("2.1", length(intersect(sol_rows, stud_rows))))
-            print(paste("2.2", length(sol_rows)))
             equal <- (length(intersect(sol_cols, stud_cols)) >= length(sol_cols) && 
                       length(intersect(sol_rows, stud_rows)) >= length(sol_rows))||
                      (length(intersect(sol_rows, stud_cols)) >= length(sol_rows) && 

--- a/utils-plot.R
+++ b/utils-plot.R
@@ -1,26 +1,70 @@
 # These functions were inspired by the check_ggplot functions of the testwhat package https://github.com/datacamp/testwhat
 
 test_data_layer <- function(sol_data, stud_data) {
-    feedback <- "You did not add the correct data."
-    list('equal' = isTRUE(all.equal(sol_data, stud_data)), 'feedback' = feedback)
-}
-
-test_aes_layer <- function(sol_mapping, stud_mapping) {
-    for (map in names(sol_mapping)) {
-        feedback_msg <- c(paste0("Have you specified the `", map, "` aesthetic?"),
-                          paste0("Found `", stud_mapping[map], "` for the `", map, "` aesthetic. Expected `", sol_mapping[map], "`."))
-
-        if (is.null(stud_mapping[map][[1]])){
-            return(list('equal' = FALSE, 'feedback' = feedback_msg[1]))
-        }
-        if(!isTRUE(all.equal(stud_mapping[map], sol_mapping[map], check.attributes = FALSE))){
-            return(list('equal' = FALSE, 'feedback' = feedback_msg[2]))
-        }
+    equal_names <- names(sol_data) %in% names(stud_data)
+    equal <- all(equal_names)
+    feedback <- paste0("You did not add the correct data, missing ", ifelse(sum(equal_names)==1, "column", "columns"), " named: ", names(sol_data)[!equal_names])
+    if(equal){
+        equal <- isTRUE(all.equal(select(sol_data, names(sol_data)), select(stud_data, names(sol_data))))
+        feedback <- "The data you used in your ggplot contains the right column names but is wrong"
     }
-    return(list('equal' = TRUE, 'feedback' = ""))
+    list('equal' = equal, 'feedback' = feedback)
 }
 
-test_geom_layer <- function(sol_layers, stud_layers) {
+test_facet_layer <- function(sol_facet, stud_facet) {
+    sol_type <- class(sol_facet)[1]
+    stud_type <- class(stud_facet)[1]
+    if(sol_type == "FacetNull"){
+        return(list('equal' = TRUE, 'feedback' = ""))
+    }
+    if(stud_type == "FacetNull"){
+        return(list('equal' = FALSE, 'feedback' = "Did you define a multipanel plot?"))
+    }
+    equal <- FALSE
+    # A faced wrap student code can be matched with a faced grid solution if the solution has 1 row or column and the other way arround
+    if (sol_type == "FacetGrid") {
+        sol_cols <- names(sol_facet$params$cols)
+        sol_rows <- names(sol_facet$params$rows)
+        if (stud_type == "FacetGrid") {
+            stud_cols <- names(stud_facet$params$cols)
+            stud_rows <- names(stud_facet$params$rows)
+            print(paste("1.1", length(intersect(sol_cols, stud_cols))))
+            print(paste("1.2", length(sol_cols)))
+            print(paste("2.1", length(intersect(sol_rows, stud_rows))))
+            print(paste("2.2", length(sol_rows)))
+            equal <- (length(intersect(sol_cols, stud_cols)) >= length(sol_cols) && 
+                      length(intersect(sol_rows, stud_rows)) >= length(sol_rows))||
+                     (length(intersect(sol_rows, stud_cols)) >= length(sol_rows) && 
+                      length(intersect(sol_cols, stud_rows)) >= length(sol_cols))
+        } else if (stud_type == "FacetWrap" && (length(sol_cols) == 0 || length(sol_rows) == 0)){
+            stud_facets <- names(stud_facet$params$facets)
+            equal <- length(intersect(sol_cols, stud_facets)) >= length(sol_cols)||
+                     length(intersect(sol_rows, stud_facets)) >= length(sol_rows)
+        }
+        if(length(sol_cols) == 0 || length(sol_rows) == 0){
+            return(list('equal' = equal, 'feedback' = paste0("Did you make a multipanel plot with rows or columns at least divided by (", c(sol_rows, sol_cols), ")?")))
+        } else {
+            return(list('equal' = equal, 'feedback' = paste0("Did you make a multipanel plot with rows and columns respectively divided by (", sol_rows, "), (", sol_cols, ") or the other way arround?")))
+        }
+        
+    } else if (sol_type == "FacetWrap"){
+        sol_facets <- names(sol_facet$params$facets)
+        if (stud_type == "FacetGrid") {
+            stud_cols <- names(stud_facet$params$cols)
+            stud_rows <- names(stud_facet$params$rows)
+            equal <- length(intersect(sol_facets, stud_cols)) >= length(sol_facets)||
+                     length(intersect(sol_facets, stud_rows)) >= length(sol_facets)
+        } else if (stud_type == "FacetWrap") {
+            stud_facets <- names(stud_facet$params$facets)
+            equal <- length(intersect(sol_facets, stud_facets)) >= length(sol_facets)
+        }
+        return(list('equal' = equal, 'feedback' = ifelse(equal, "", paste0("Did you make a multipanel plot with rows or columns at least divided by (", sol_facets, ")?")))) 
+    }
+}
+
+test_geom_layer <- function(sol_gg, stud_gg){
+    sol_layers <- sol_gg$layers
+    stud_layers <- stud_gg$layers
     nb_sol_layers <- length(sol_layers)
 
     if (!(nb_sol_layers > 0)) {
@@ -37,41 +81,66 @@ test_geom_layer <- function(sol_layers, stud_layers) {
 
         sol_geom_type <- get_type(sol_layer$geom)
 
-        nb_stud_layers <- length(stud_layers)
-        if (nb_stud_layers > 0) {
-            for (j in 1:nb_stud_layers) {
-                stud_layer <- stud_layers[[j]]
+        for (j in seq_along(stud_layers)) {
+            stud_layer <- stud_layers[[j]]
 
-                stud_geom_type <- get_type(stud_layer$geom)
-                if (sol_geom_type == stud_geom_type) {
-                    found_geom <- TRUE
-                    found_params <- TRUE
+            stud_geom_type <- get_type(stud_layer$geom)
+            if (sol_geom_type == stud_geom_type) {
 
-                    stud_params <- get_params(stud_layer)
+                # Testing aes for every layer, we will check if every aes component of a layer in the solution-plot is
+                # also specified in the corresponding layer of the student-plot or in the aes of the base ggplot function
+                mapping_keys <- unique(c(names(sol_layer$mapping), names(sol_gg$mapping)))
+                for(key in mapping_keys){
 
-                    for (sol_param in names(sol_params)) {
-                        if (!(sol_param %in% names(stud_params))) {
-                            found_params <- FALSE
-                            break
-                        } else {
-                            sol_value <- sol_params[[sol_param]]
-                            stud_value <- stud_params[[sol_param]]
-
-                            if (!isTRUE(all.equal(sol_value, stud_value))) {
-                                found_params <- FALSE
-                                break
-                            }
+                    stud_map_component <- stud_layer$mapping[key]
+                    if (is.null(stud_map_component[[1]])){
+                        stud_map_component <- stud_gg$mapping[key]
+                        if (is.null(stud_map_component[[1]])){
+                            return(list('equal' = FALSE, 
+                                        'feedback' = paste0("Have you specified the `", key, "` aesthetic needed in the `", as.character(sol_geom_type), "` layer?"))
+                            )
                         }
                     }
 
-                    if (found_params) {
-                        found_geom_with_params <- TRUE
+                    sol_map_component <- sol_layer$mapping[key]
+                    if (is.null(sol_map_component[[1]])){
+                        sol_map_component <- sol_gg$mapping[key]
                     }
 
-                    if (found_geom_with_params) {
-                        stud_layers[[j]] <- NULL
-                        break
+                    if(!isTRUE(all.equal(stud_map_component, sol_map_component, check.attributes = FALSE))){
+                        return(list('equal' = FALSE, 
+                                    'feedback' = paste0("Found `", stud_map_component, "` for the `", key, "` aesthetic. Expected `", sol_map_component, "`."))
+                        )
                     }
+                }
+
+                found_geom <- TRUE
+                found_params <- TRUE
+
+                stud_params <- get_params(stud_layer)
+
+                for (sol_param in names(sol_params)) {
+                    if (!(sol_param %in% names(stud_params))) {
+                        found_params <- FALSE
+                        break
+                    } else {
+                        sol_value <- sol_params[[sol_param]]
+                        stud_value <- stud_params[[sol_param]]
+
+                        if (!isTRUE(all.equal(sol_value, stud_value))) {
+                            found_params <- FALSE
+                            break
+                        }
+                    }
+                }
+
+                if (found_params) {
+                    found_geom_with_params <- TRUE
+                }
+
+                if (found_geom_with_params) {
+                    stud_layers[[j]] <- NULL
+                    break
                 }
             }
         }
@@ -93,8 +162,6 @@ get_params <- function(geom_layer) {
     params <- geom_layer$geom_params
     stat_params <- geom_layer$stat_params
     params[names(stat_params)] <- stat_params
-    mapping_params <- lapply(geom_layer$mapping, function(x) structure(x, aes = TRUE))
-    params[names(mapping_params)] <- mapping_params
     aes_params <- geom_layer$aes_params
     params[names(aes_params)] <- aes_params
     return(params)


### PR DESCRIPTION
additions:
+ facet layer test added
+ option to prevent the solution is showed to the student when a wrong solution is given

improvements:
* test_aes_layer function is more flexible. The algorithm will compare the aes for each layer corresponding geometric layers of the student and the solution plot. When an aes component is not explicitly specified in a geometric layer it will look at the defaults set in the aes of the ggplot function.
*  test_data_layer function is more flexible. The judge now tests if the expected data from the solution plot is contained in the passed data instead of "equal to".

very small things: 
* quiet parameter added to knittr::purl in contextWithRmd 
* for loop simplified with "seq_along" function