### PR TITLE
ggplot memory efficiency improved

### DIFF
--- a/test.R
+++ b/test.R
@@ -162,7 +162,7 @@ testGGPlot <- function(description, generated, expected, show_expected = TRUE,
                  if (equal) {
                      get_reporter()$end_test("", "correct")
                  } else {
-                     if(show_expected && plot_exists){
+                     if(show_expected && plot_exists) {
                         image_expected <- base64enc::base64encode(tf_expected)
                         get_reporter()$add_message(paste("<img style=\"max-width:100%; width:450px;\" src=\"data:image/png;base64,", image_expected, "\"/>", sep=''), type = "html")
                      }

--- a/test.R
+++ b/test.R
@@ -99,7 +99,7 @@ testGGPlot <- function(description, generated, expected, show_expected = TRUE,
                  expected_gg <- expected
                  generated_gg <- generated(test_env$clean_env)
 
-                 if(show_expected){
+                 if(show_expected) {
                     expected_gg$labels$title <- paste(expected_gg$labels$title, "(Expected Plot)")
                     suppressMessages(ggsave(tf_expected <- tempfile(fileext = ".png"), plot = expected_gg, dpi = "screen"))
                  }

--- a/test.R
+++ b/test.R
@@ -167,7 +167,7 @@ testGGPlot <- function(description, generated, expected, show_expected = TRUE,
                  if (show_expected && file.exists(tf_expected)) {
                     file.remove(tf_expected)
                  }
-                 if (file.exists(tf_generated)){
+                 if (file.exists(tf_generated)) {
                      file.remove(tf_generated)
                  }                 
              },

--- a/test.R
+++ b/test.R
@@ -164,7 +164,7 @@ testGGPlot <- function(description, generated, expected, show_expected = TRUE,
                      get_reporter()$add_message(feedback)
                      get_reporter()$end_test("", "wrong")
                  }
-                 if (show_expected && file.exists(tf_expected)){
+                 if (show_expected && file.exists(tf_expected)) {
                     file.remove(tf_expected)
                  }
                  if (file.exists(tf_generated)){

--- a/test.R
+++ b/test.R
@@ -99,11 +99,12 @@ testGGPlot <- function(description, generated, expected, show_expected = TRUE,
                  expected_gg <- expected
                  generated_gg <- generated(test_env$clean_env)
 
-                 expected_gg$labels$title <- paste(expected_gg$labels$title, "(Expected Plot)")
+                 if(show_expected){
+                    expected_gg$labels$title <- paste(expected_gg$labels$title, "(Expected Plot)")
+                    suppressMessages(ggsave(tf_expected <- tempfile(fileext = ".png"), plot = expected_gg, dpi = "screen"))
+                 }
                  generated_gg$labels$title <- paste(generated_gg$labels$title, "(Generated Plot)")
-
-                 ggsave(tf_expected <- tempfile(fileext = ".png"), plot = expected_gg)
-                 ggsave(tf_generated <- tempfile(fileext = ".png"), plot = generated_gg)
+                 suppressMessages(ggsave(tf_generated <- tempfile(fileext = ".png"), plot = generated_gg, dpi = "screen"))
 
                  equal <- TRUE
                  if (test_data) {
@@ -163,6 +164,12 @@ testGGPlot <- function(description, generated, expected, show_expected = TRUE,
                      get_reporter()$add_message(feedback)
                      get_reporter()$end_test("", "wrong")
                  }
+                 if (show_expected && file.exists(tf_expected)){
+                    file.remove(tf_expected)
+                 }
+                 if (file.exists(tf_generated)){
+                     file.remove(tf_generated)
+                 }                 
              },
              warning = function(w) {
                  get_reporter()$add_message(paste("Warning while evaluating test: ", conditionMessage(w), sep = ''))


### PR DESCRIPTION
additions: 
+ ggplots plots stored in tempfiles are removed at the end of testGGPlot
+ expected solution plots are not saved when parameter `show_expected` is set to FALSE
+ plots are now saved with a smaller dpi
+ useless messages from the ggsave function are now suppressed