### PR TITLE
add rounding to testDF to add Floating Point tolerance

### DIFF
--- a/judge.R
+++ b/judge.R
@@ -4,6 +4,7 @@ source('testcase.R', local=TRUE)
 source('test.R', local=TRUE)
 source('utils-ast.R', local=TRUE)
 source('utils-plot.R', local=TRUE)
+source('utils-df.R', local=TRUE)
 
 student_code <- NULL
 

--- a/test.R
+++ b/test.R
@@ -56,7 +56,7 @@ testDF <- function(description, generated, expected, comparator = NULL, ...) {
                  equal <- FALSE
                  if (is.null(comparator)) {
                      # Use the dplyr all_equal to compare dataframes
-                     equal <- isTRUE(dplyr::all_equal(generated_val, expected, ...))
+                     equal <- isTRUE(dplyr::all_equal(round_df(generated_val), round_df(expected), ...))
                  } else {
                      equal <- comparator(generated_val, expected, ...)
                  }

--- a/utils-df.R
+++ b/utils-df.R
@@ -1,0 +1,7 @@
+round_df <- function(x) {
+    # round all numeric variables
+    # x: data frame
+    # signif rounds to 6 significant digits by default
+    x %>%
+       dplyr::mutate_if(is.numeric, signif)
+}


### PR DESCRIPTION
It seems that the dplyr::all_equal function used in testDF does not have an option to specify a tolerance for floating point numbers. This causes for example the columns:
```
(column - 32)*5/9
```
and
```
(column - 32)*(5/9)
```
To be evaluated as not equal.
I added a function that rounds numeric values in data frames to 6 significant digits to resolve this issue. This should still be sufficient precision for p-values etc.

I have placed the rounding function in utils-plot.R for now but this should probably be moved to a different file since it is not directly related to plotting.