### PR TITLE
new testDF__inReview__ function for dataframe testing with an informative feedback display

### DIFF
--- a/test.R
+++ b/test.R
@@ -85,20 +85,12 @@ testDF <- function(description, generated, expected, comparator = NULL, ...) {
 }
 
 
-testDF__inReview__ <- function(description, generated, expected, 
-                    comparator = NULL, 
-                    ignore_col_order = TRUE, 
-                    ignore_row_order = FALSE,
-                    rows_before_error = 2,
-                    rows_after_error = 2,
-                    ...
-                    ){
-
+testDF__inReview__ <- function(description, generated, expected, comparator = NULL, ignore_col_order = TRUE, ignore_row_order = FALSE, rows_before_error = 2, rows_after_error = 2, ...){
     tryCatch(
              withCallingHandlers({
 
                  capture.output(generated_val <- generated(test_env$clean_env))
-                 
+
                  #frames for custom comparator or when dataframe is correct
                  df1_bad_frame <- 1:(rows_before_error + rows_after_error + 1)
                  df2_bad_frame <- df1_bad_frame
@@ -113,19 +105,19 @@ testDF__inReview__ <- function(description, generated, expected,
 
                  if (is.null(comparator)) {
                      # Use the dplyr all_equal to compare dataframes
-                     test_result <- dataframe_all_equal(generated_val, expected, 
-                                                        ignore_col_order = ignore_col_order, 
+                     test_result <- dataframe_all_equal(generated_val, expected,
+                                                        ignore_col_order = ignore_col_order,
                                                         ignore_row_order = ignore_row_order,
                                                         before_error = rows_before_error,
                                                         after_error = rows_after_error
-                                                        )
+                     )
                      equal <- test_result$equal
                      if(!equal){
-                        df1_bad_frame <- test_result$df1_rows
-                        df2_bad_frame <- test_result$df2_rows
-                        df2_cols <- test_result$df2_cols
-                        feedback <- test_result$feedback
-                     } 
+                         df1_bad_frame <- test_result$df1_rows
+                         df2_bad_frame <- test_result$df2_rows
+                         df2_cols <- test_result$df2_cols
+                         feedback <- test_result$feedback
+                     }
                  } else {
                      equal <- comparator(generated_val, expected, ...)
                  }
@@ -133,7 +125,7 @@ testDF__inReview__ <- function(description, generated, expected,
                  generated_df_view <- dplyr::slice(generated_val, df1_bad_frame)
                  expected_df_view <- dplyr::slice(expected, df2_bad_frame)
                  expected_df_view <- expected_df_view[df2_cols]
-                 
+
                  get_reporter()$start_test(paste(knitr::kable(expected_df_view, "simple", row.names = FALSE), collapse = '\n'), description)
                  get_reporter()$add_message(paste0(nrow(generated_df_view), " of the ", nrow(generated_val), " generated rows are shown."))
                  if (equal) {
@@ -161,14 +153,7 @@ testDF__inReview__ <- function(description, generated, expected,
     )
 }
 
-testGGPlot <- function(description, generated, expected, show_expected = TRUE,
-                        test_data = TRUE,
-                        test_geom = TRUE,
-                        test_facet = TRUE,
-                        test_label = FALSE,
-                        test_scale = FALSE
-                        ) {
-
+testGGPlot <- function(description, generated, expected, show_expected = TRUE, test_data = TRUE, test_geom = TRUE, test_facet = TRUE, test_label = FALSE, test_scale = FALSE) {
     get_reporter()$start_test("", description)
 
     tryCatch(

--- a/test.R
+++ b/test.R
@@ -169,9 +169,6 @@ testGGPlot <- function(description, generated, expected, show_expected = TRUE,
                         test_scale = FALSE
                         ) {
 
-
-testGGPlot <- function(description, generated, expected, show_expected = TRUE, test_data = TRUE, test_geom = TRUE, test_facet = TRUE, test_label = FALSE, test_scale = FALSE) {
-
     get_reporter()$start_test("", description)
 
     tryCatch(

--- a/test.R
+++ b/test.R
@@ -112,7 +112,7 @@ testDF2 <- function(description, generated, expected,
 
                  if (is.null(comparator)) {
                      # Use the dplyr all_equal to compare dataframes
-                     test_result <- dataframe_all_equal(round_df(generated_val), round_df(expected), 
+                     test_result <- dataframe_all_equal(generated_val, expected, 
                                                         ignore_col_order = ignore_col_order, 
                                                         ignore_row_order = ignore_row_order,
                                                         before_error = rows_before_error,

--- a/test.R
+++ b/test.R
@@ -84,7 +84,7 @@ testDF <- function(description, generated, expected, comparator = NULL, ...) {
     )
 }
 
-testDF2 <- function(description, generated, expected, 
+testDF__inReview__ <- function(description, generated, expected, 
                     comparator = NULL, 
                     ignore_col_order = TRUE, 
                     ignore_row_order = FALSE,

--- a/utils-df.R
+++ b/utils-df.R
@@ -10,7 +10,11 @@ round_df <- function(x) {
 #df1 is the dataframe from which the order of collumns and rows will be preserved when ignore_col_order or ignore_row_order is set to TRUE
 dataframe_all_equal <- function(df1, df2, ignore_col_order = TRUE, ignore_row_order = FALSE, after_error=2, before_error=2){
     
-    # change the column order of df2 to match df1
+    # rounding to avoid identical testing
+    df1 <- round_df(df1)
+    df2 <- round_df(df2)
+
+    # change the column order of df2 to match df1 if needed
     if (ignore_col_order){
         df2 <- df2[intersect(names(df1), names(df2))]
     }
@@ -50,8 +54,9 @@ dataframe_all_equal <- function(df1, df2, ignore_col_order = TRUE, ignore_row_or
             } else {# search a match for this row
                 df2_row_ind <- 1
                 while(df2_row_ind <= length(df2_row_options) && 
+                        #TODO write a function that can also test for row.names so that row names can be displayed in the future
+                        #look into: !isTRUE(all.equal(df1[df1_row,], df2[df2_row_options[df2_row_ind],], use.names = TRUE,check.attributes = FALSE)))
                         !isTRUE(dplyr::all_equal(df1[df1_row,], df2[df2_row_options[df2_row_ind],], ignore_col_order = FALSE, ignore_row_order = FALSE)))
-                      #!isTRUE(all.equal(df1[df1_row,], df2[df2_row_options[df2_row_ind],], use.names = FALSE,check.attributes = FALSE)))
                       {
 
                     df2_row_ind <- df2_row_ind + 1
@@ -66,35 +71,17 @@ dataframe_all_equal <- function(df1, df2, ignore_col_order = TRUE, ignore_row_or
                     df2_matches <- c(df2_matches, df2_row_options[df2_row_ind])
                 }
             }
-            
-            print(paste("########################### df1_row: ", df1_row, " ###############################"))
-            print(paste("matches: ", df1[df1_row,]))
         }
-        print("no_match_count")
-        print(no_match_count)
-        print("**********************matches**************************")
-        print(paste(knitr::kable(dplyr::slice(df2, df2_matches), "simple", row.names = TRUE), collapse = '\n'))
-        print("**********************generated**************************")
-        print(paste(knitr::kable(dplyr::slice(df1, 1:df1_row), "simple", row.names = TRUE), collapse = '\n'))
 
         # add unmatched rows from df2 to df2_matches if needed
         df2_row_options <- c(1:nrow(df2))[!c(1:nrow(df2)) %in% df2_matches]
         to_add <- min(after_error - (past_error - no_match_count), nrow(df1) - length(df2_matches))
-        print("to add: ")
-        print(to_add)
         if(to_add > 0){
             df2_matches <- c(df2_matches, df2_row_options[1:to_add])
         }
         
         eind <- length(df2_matches)
         begin <- max(1, eind - (before_error + after_error))
-        print("nrow(df1)")
-        print(nrow(df1))
-        print("begin:")
-        print(begin)
-        print("einde:")
-        print(eind)
-        print(df2_matches)
         return(list(
             'equal' = !error, 
             'df1_rows' = begin:eind, 

--- a/utils-df.R
+++ b/utils-df.R
@@ -21,6 +21,7 @@ dataframe_all_equal <- function(df1, df2, ignore_col_order = TRUE, ignore_row_or
         no_match_count <- 0
         df2_matches <- c()
         past_error <- 0
+
         # loop over every df1 row and find its match
         df1_row <- 0
         while((df1_row < nrow(df1) || length(df2_matches) < nrow(df2)) && 
@@ -39,8 +40,7 @@ dataframe_all_equal <- function(df1, df2, ignore_col_order = TRUE, ignore_row_or
                 if(!error){
                     error <- TRUE
                     textual_feedback <- "Your dataframe is missing at least one row."
-                }
-                
+                } 
             } else if (length(df2_row_options) == 0){# no possible matches left, df1 has a row too much                
                 df2_matches <- c(df2_matches, NA)
                 if(!error){
@@ -50,7 +50,9 @@ dataframe_all_equal <- function(df1, df2, ignore_col_order = TRUE, ignore_row_or
             } else {# search a match for this row
                 df2_row_ind <- 1
                 while(df2_row_ind <= length(df2_row_options) && 
-                      !isTRUE(all.equal(df1[df1_row,], df2[df2_row_options[df2_row_ind],], use.names = FALSE,check.attributes = FALSE))){
+                        !isTRUE(dplyr::all_equal(df1[df1_row,], df2[df2_row_options[df2_row_ind],], ignore_col_order = FALSE, ignore_row_order = FALSE)))
+                      #!isTRUE(all.equal(df1[df1_row,], df2[df2_row_options[df2_row_ind],], use.names = FALSE,check.attributes = FALSE)))
+                      {
 
                     df2_row_ind <- df2_row_ind + 1
                 }
@@ -58,7 +60,7 @@ dataframe_all_equal <- function(df1, df2, ignore_col_order = TRUE, ignore_row_or
                     no_match_count <- no_match_count + 1
                     if(!error){
                         error <- TRUE
-                        textual_feedback <- "Your dataframe contains a row which is not found in the solution."
+                        textual_feedback <- "Your dataframe contains at least one row which is not found in the solution."
                     }
                 } else { # match found!!
                     df2_matches <- c(df2_matches, df2_row_options[df2_row_ind])

--- a/utils-df.R
+++ b/utils-df.R
@@ -3,13 +3,12 @@ round_df <- function(x) {
     # x: data frame
     # signif rounds to 6 significant digits by default
     x %>%
-       dplyr::mutate_if(is.numeric, signif)
+        dplyr::mutate_if(is.numeric, signif)
 }
 
 
 #df1 is the dataframe from which the order of collumns and rows will be preserved when ignore_col_order or ignore_row_order is set to TRUE
-dataframe_all_equal <- function(df1, df2, ignore_col_order = TRUE, ignore_row_order = FALSE, after_error=2, before_error=2){
-    
+dataframe_all_equal <- function(df1, df2, ignore_col_order = TRUE, ignore_row_order = FALSE, after_error = 2, before_error = 2) {
     # rounding to avoid identical testing
     df1 <- round_df(df1)
     df2 <- round_df(df2)
@@ -28,12 +27,12 @@ dataframe_all_equal <- function(df1, df2, ignore_col_order = TRUE, ignore_row_or
 
         # loop over every df1 row and find its match
         df1_row <- 0
-        while((df1_row < nrow(df1) || length(df2_matches) < nrow(df2)) && 
+        while((df1_row < nrow(df1) || length(df2_matches) < nrow(df2)) &&
               (past_error < after_error + no_match_count || df1_row <= after_error + before_error + no_match_count)){
 
             df1_row <- df1_row + 1
             df2_row_options <- c(1:nrow(df2))[!c(1:nrow(df2)) %in% df2_matches]
-            
+
             if(error){
                 past_error <- past_error + 1
             }
@@ -44,8 +43,8 @@ dataframe_all_equal <- function(df1, df2, ignore_col_order = TRUE, ignore_row_or
                 if(!error){
                     error <- TRUE
                     textual_feedback <- "Your dataframe is missing at least one row."
-                } 
-            } else if (length(df2_row_options) == 0){# no possible matches left, df1 has a row too much                
+                }
+            } else if (length(df2_row_options) == 0){# no possible matches left, df1 has a row too much
                 df2_matches <- c(df2_matches, NA)
                 if(!error){
                     error <- TRUE
@@ -53,15 +52,15 @@ dataframe_all_equal <- function(df1, df2, ignore_col_order = TRUE, ignore_row_or
                 }
             } else {# search a match for this row
                 df2_row_ind <- 1
-                while(df2_row_ind <= length(df2_row_options) && 
-                        #TODO write a function that can also test for row.names so that row names can be displayed in the future
-                        #look into: !isTRUE(all.equal(df1[df1_row,], df2[df2_row_options[df2_row_ind],], use.names = TRUE,check.attributes = FALSE)))
-                        !isTRUE(dplyr::all_equal(df1[df1_row,], df2[df2_row_options[df2_row_ind],], ignore_col_order = FALSE, ignore_row_order = FALSE)))
-                      {
+                while(df2_row_ind <= length(df2_row_options) &&
+                      #TODO write a function that can also test for row.names so that row names can be displayed in the future
+                      #look into: !isTRUE(all.equal(df1[df1_row,], df2[df2_row_options[df2_row_ind],], use.names = TRUE,check.attributes = FALSE)))
+                      !isTRUE(dplyr::all_equal(df1[df1_row,], df2[df2_row_options[df2_row_ind],], ignore_col_order = FALSE, ignore_row_order = FALSE)))
+                {
 
                     df2_row_ind <- df2_row_ind + 1
                 }
-                if(df2_row_ind > length(df2_row_options)){ # no match found                    
+                if(df2_row_ind > length(df2_row_options)){ # no match found
                     no_match_count <- no_match_count + 1
                     if(!error){
                         error <- TRUE
@@ -79,16 +78,16 @@ dataframe_all_equal <- function(df1, df2, ignore_col_order = TRUE, ignore_row_or
         if(to_add > 0){
             df2_matches <- c(df2_matches, df2_row_options[1:to_add])
         }
-        
+
         eind <- length(df2_matches)
         begin <- max(1, eind - (before_error + after_error))
         return(list(
-            'equal' = !error, 
-            'df1_rows' = begin:eind, 
-            'df2_rows' = tail(df2_matches, after_error + before_error + 1), 
-            'df2_cols' = names(df2),
-            "feedback" = textual_feedback
-        )) 
+                    'equal' = !error,
+                    'df1_rows' = begin:eind,
+                    'df2_rows' = tail(df2_matches, after_error + before_error + 1),
+                    'df2_cols' = names(df2),
+                    "feedback" = textual_feedback
+                    ))
 
     } else {
         df_row <- 0
@@ -101,16 +100,16 @@ dataframe_all_equal <- function(df1, df2, ignore_col_order = TRUE, ignore_row_or
             if (!identical(df1[df_row,], df2[df_row,]) && !error){
                 textual_feedback <- paste0("unexpected row with rownumber: ", df_row)
                 error <- TRUE
-            } 
+            }
         }
         eind <- df_row
         begin <- max(1, eind - (after_error + before_error))
         return(list(
-            'equal' = !error, 
-            'df1_rows' = begin:eind, 
-            'df2_rows' = begin:eind,
-            'df2_cols' = names(df2),
-            'feedback' = textual_feedback
-        )) 
+                    'equal' = !error,
+                    'df1_rows' = begin:eind,
+                    'df2_rows' = begin:eind,
+                    'df2_cols' = names(df2),
+                    'feedback' = textual_feedback
+                    ))
     }
 }

--- a/utils-df.R
+++ b/utils-df.R
@@ -5,3 +5,123 @@ round_df <- function(x) {
     x %>%
        dplyr::mutate_if(is.numeric, signif)
 }
+
+
+#df1 is the dataframe from which the order of collumns and rows will be preserved when ignore_col_order or ignore_row_order is set to TRUE
+dataframe_all_equal <- function(df1, df2, ignore_col_order = TRUE, ignore_row_order = FALSE, after_error=2, before_error=2){
+    
+    # change the column order of df2 to match df1
+    if (ignore_col_order){
+        df2 <- df2[intersect(names(df1), names(df2))]
+    }
+
+    error <- FALSE
+    textual_feedback <- ""
+    if (ignore_row_order){
+        no_match_count <- 0
+        df2_matches <- c()
+        past_error <- 0
+        # loop over every df1 row and find its match
+        df1_row <- 0
+        while((df1_row < nrow(df1) || length(df2_matches) < nrow(df2)) && 
+              (past_error < after_error + no_match_count || df1_row <= after_error + before_error + no_match_count)){
+
+            df1_row <- df1_row + 1
+            df2_row_options <- c(1:nrow(df2))[!c(1:nrow(df2)) %in% df2_matches]
+            
+            if(error){
+                past_error <- past_error + 1
+            }
+
+            if(df1_row > nrow(df1)){# df1 is missing a row
+                # if we reach this case we are sure that df2_row_options contains at least 1 element
+                df2_matches <- c(df2_matches, df2_row_options[1])
+                if(!error){
+                    error <- TRUE
+                    textual_feedback <- "Your dataframe is missing at least one row."
+                }
+                
+            } else if (length(df2_row_options) == 0){# no possible matches left, df1 has a row too much                
+                df2_matches <- c(df2_matches, NA)
+                if(!error){
+                    error <- TRUE
+                    textual_feedback <- "Your dataframe contains at least one row too much."
+                }
+            } else {# search a match for this row
+                df2_row_ind <- 1
+                while(df2_row_ind <= length(df2_row_options) && 
+                      !isTRUE(all.equal(df1[df1_row,], df2[df2_row_options[df2_row_ind],], use.names = FALSE,check.attributes = FALSE))){
+
+                    df2_row_ind <- df2_row_ind + 1
+                }
+                if(df2_row_ind > length(df2_row_options)){ # no match found                    
+                    no_match_count <- no_match_count + 1
+                    if(!error){
+                        error <- TRUE
+                        textual_feedback <- "Your dataframe contains a row which is not found in the solution."
+                    }
+                } else { # match found!!
+                    df2_matches <- c(df2_matches, df2_row_options[df2_row_ind])
+                }
+            }
+            
+            print(paste("########################### df1_row: ", df1_row, " ###############################"))
+            print(paste("matches: ", df1[df1_row,]))
+        }
+        print("no_match_count")
+        print(no_match_count)
+        print("**********************matches**************************")
+        print(paste(knitr::kable(dplyr::slice(df2, df2_matches), "simple", row.names = TRUE), collapse = '\n'))
+        print("**********************generated**************************")
+        print(paste(knitr::kable(dplyr::slice(df1, 1:df1_row), "simple", row.names = TRUE), collapse = '\n'))
+
+        # add unmatched rows from df2 to df2_matches if needed
+        df2_row_options <- c(1:nrow(df2))[!c(1:nrow(df2)) %in% df2_matches]
+        to_add <- min(after_error - (past_error - no_match_count), nrow(df1) - length(df2_matches))
+        print("to add: ")
+        print(to_add)
+        if(to_add > 0){
+            df2_matches <- c(df2_matches, df2_row_options[1:to_add])
+        }
+        
+        eind <- length(df2_matches)
+        begin <- max(1, eind - (before_error + after_error))
+        print("nrow(df1)")
+        print(nrow(df1))
+        print("begin:")
+        print(begin)
+        print("einde:")
+        print(eind)
+        print(df2_matches)
+        return(list(
+            'equal' = !error, 
+            'df1_rows' = begin:eind, 
+            'df2_rows' = tail(df2_matches, after_error + before_error + 1), 
+            'df2_cols' = names(df2),
+            "feedback" = textual_feedback
+        )) 
+
+    } else {
+        df_row <- 0
+        past_error <- 0
+        while(df_row < max(nrow(df1), nrow(df2)) && (past_error < after_error || df_row <= after_error + before_error + 1)){
+            df_row <- df_row + 1
+            if(error){
+                past_error <- past_error + 1
+            }
+            if (!identical(df1[df_row,], df2[df_row,]) && !error){
+                textual_feedback <- paste0("unexpected row with rownumber: ", df_row)
+                error <- TRUE
+            } 
+        }
+        eind <- df_row
+        begin <- max(1, eind - (after_error + before_error))
+        return(list(
+            'equal' = !error, 
+            'df1_rows' = begin:eind, 
+            'df2_rows' = begin:eind,
+            'df2_cols' = names(df2),
+            'feedback' = textual_feedback
+        )) 
+    }
+}


### PR DESCRIPTION
A new dataframe testing function `testDF__inReview__` is added, which should be very similar to the already existing `testDF` function but with some extra functionalities. This function shows the rows contained within a bounding box around the first error encountered instead of the first 5 rows.

The new function `testDF__inReview__`  should be backwards compatible with `testDF` so it can easily replace the old one in the near future (after serious testing). However I did not overwrite the old function yet because I think it's a good idea to first test this function on a few exercises to avoid bigger problems. Because of this reason no documentation was written either (hopefully the name will be changed in the near future).

The other options is that I write the documentation with a warning that this function shouldn't be used?