### PR TITLE
Update test.R

### DIFF
--- a/test.R
+++ b/test.R
@@ -63,7 +63,7 @@ testDF <- function(description, generated, expected, comparator = NULL, ignore_r
                          expected <- expected[do.call(order, expected),]
                          generated_val <- generated_val[do.call(order, generated_val),]
                      }
-                     equal <- isTRUE(all.equal(generated_val, expected), ...)
+                     equal <- isTRUE(all.equal(generated_val, expected, ...))
                  } else {
                      equal <- comparator(generated_val, expected, ...)
                  }


### PR DESCRIPTION
Change on line 66: if arguments like 'tolerance' are to be passed to is.equal(), then the ellipsis argument (...) should be inside both brackets. R's function isTRUE() can only handle an argument 'x' so no ...