### PR TITLE
Fixed bug in test_facet_layer + added ignore_facet_type argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The `testGGPlot` function can be used to test the equality of `GGPlot`s. Aside f
 - `test_data = TRUE` A logical value indicating whether the input data to the `ggplot` function should be verified. This test will succeed if all columns from the solution have a corresponding column in the given input with the same column name and data.
 - `test_geom = TRUE` A logical value indicating whether the geometric layers should be checked. For each layer the parameters and aesthetics are verified. This test method also takes into account the default aesthetics set in the `ggplot` function itself.
 - `test_facet = TRUE` A logical value indicating whether the facet layer should be tested. This test supports `facet_grid` and `facet_wrap` layers and can compare them to one another (e.g. a `facet_grid` with only 1 row/column can be equal to a `facet_wrap` and vice versa).
+- `ignore_facet_type = TRUE` A logical value indicating whether the facet type should be tested when testing the facet layer. Even though `facet_grid` and `facet_wrap` return similar graphs, the instructor may want to force `facet_grid` as it can create clearer graphs when facetting with multiple variables.
 - `test_label = FALSE` A logical value indicating whether the label layers should be tested.
 - `test_scale = FALSE` A logical value indicating whether the scale of the axis should be tested.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The `testGGPlot` function can be used to test the equality of `GGPlot`s. Aside f
 - `test_data = TRUE` A logical value indicating whether the input data to the `ggplot` function should be verified. This test will succeed if all columns from the solution have a corresponding column in the given input with the same column name and data.
 - `test_geom = TRUE` A logical value indicating whether the geometric layers should be checked. For each layer the parameters and aesthetics are verified. This test method also takes into account the default aesthetics set in the `ggplot` function itself.
 - `test_facet = TRUE` A logical value indicating whether the facet layer should be tested. This test supports `facet_grid` and `facet_wrap` layers and can compare them to one another (e.g. a `facet_grid` with only 1 row/column can be equal to a `facet_wrap` and vice versa).
-- `ignore_facet_type = TRUE` A logical value indicating whether the facet type should be tested when testing the facet layer. Even though `facet_grid` and `facet_wrap` return similar graphs, the instructor may want to force `facet_grid` as it can create clearer graphs when facetting with multiple variables.
+- `ignore_facet_type = TRUE` A logical value indicating whether the facet type should be tested when testing the facet layer. Even though `facet_grid` and `facet_wrap` return similar graphs, the instructor may want to force `facet_grid` as it can create clearer graphs when faceting with multiple variables.
 - `test_label = FALSE` A logical value indicating whether the label layers should be tested.
 - `test_scale = FALSE` A logical value indicating whether the scale of the axis should be tested.
 

--- a/test.R
+++ b/test.R
@@ -162,7 +162,7 @@ testDF__inReview__ <- function(description, generated, expected, comparator = NU
     )
 }
 
-testGGPlot <- function(description, generated, expected, show_expected = TRUE, test_data = TRUE, test_geom = TRUE, test_facet = TRUE, test_label = FALSE, test_scale = FALSE) {
+testGGPlot <- function(description, generated, expected, show_expected = TRUE, test_data = TRUE, test_geom = TRUE, test_facet = TRUE, test_label = FALSE, test_scale = FALSE, ...) {
     get_reporter()$start_test("", description)
 
     tryCatch(
@@ -202,7 +202,7 @@ testGGPlot <- function(description, generated, expected, show_expected = TRUE, t
                  }
 
                  if (test_facet && equal) {
-                     test_facet_result <- test_facet_layer(expected_gg$facet, generated_gg$facet)
+                     test_facet_result <- test_facet_layer(expected_gg$facet, generated_gg$facet, ...)
                      if (!test_facet_result$equal) {
                          feedback <- test_facet_result$feedback
                          equal <- FALSE

--- a/utils-plot.R
+++ b/utils-plot.R
@@ -12,45 +12,45 @@ test_data_layer <- function(sol_data, stud_data) {
 }
 
 test_facet_layer <- function(sol_facet, stud_facet, ignore_facet_type = TRUE) {
-  sol_type <- class(sol_facet)[1]
-  stud_type <- class(stud_facet)[1]
-  
-  if (sol_type == "FacetNull") {
-    return(list('equal' = TRUE, 'feedback' = ""))
-  }
-  if (stud_type == "FacetNull") {
-    return(list('equal' = FALSE, 'feedback' = "Did you define a multipanel plot?"))
-  }
-  equal <- FALSE
-  
-  if (ignore_facet_type) {
-    equal <- setequal(sol_facet$vars(), stud_facet$vars())
-    return(list('equal' = equal, 'feedback' = ifelse(equal, "", paste0("Did you make a multipanel plot with rows or columns at least divided by (", paste0(sol_facet$vars(), collapse = ", "), ")?")))) 
-  } else {
-    if (sol_type == "FacetWrap") {
-      if (stud_type  == "FacetWrap") {
+    sol_type <- class(sol_facet)[1]
+    stud_type <- class(stud_facet)[1]
+    
+    if (sol_type == "FacetNull") {
+        return(list('equal' = TRUE, 'feedback' = ""))
+    }
+    if (stud_type == "FacetNull") {
+        return(list('equal' = FALSE, 'feedback' = "Did you define a multipanel plot?"))
+    }
+    equal <- FALSE
+    
+    if (ignore_facet_type) {
         equal <- setequal(sol_facet$vars(), stud_facet$vars())
         return(list('equal' = equal, 'feedback' = ifelse(equal, "", paste0("Did you make a multipanel plot with rows or columns at least divided by (", paste0(sol_facet$vars(), collapse = ", "), ")?")))) 
-      } else {
-        return(list('equal' = FALSE, `feedback` = "Did you use the facet_wrap layer?"))
-      }
     } else {
-      if (stud_type  == "FacetGrid") {
-        
-        sol_rows <- names(sol_facet$params$rows)
-        sol_cols <- names(sol_facet$params$cols)
-        
-        stud_rows <- names(stud_facet$params$rows)
-        stud_cols <- names(stud_facet$params$cols)
-        
-        #Cols and rows can be interchanged
-        equal <- (setequal(sol_rows, stud_rows) & setequal(sol_cols, stud_cols)) | (setequal(sol_rows, stud_cols) & setequal(sol_cols, stud_rows))  
-        return(list('equal' = equal, 'feedback' = ifelse(equal, "", paste0("Did you make a multipanel plot with rows or columns at least divided by (", paste0(sol_facet$vars(), collapse = ", "), ")?")))) 
-      } else {
-        return(list('equal' = FALSE, `feedback` = "Did you use the facet_grid layer?"))
-      }
-    }
-  } 
+        if (sol_type == "FacetWrap") {
+            if (stud_type  == "FacetWrap") {
+                equal <- setequal(sol_facet$vars(), stud_facet$vars())
+                return(list('equal' = equal, 'feedback' = ifelse(equal, "", paste0("Did you make a multipanel plot with rows or columns at least divided by (", paste0(sol_facet$vars(), collapse = ", "), ")?")))) 
+            } else {
+                return(list('equal' = FALSE, `feedback` = "Did you use the facet_wrap layer?"))
+            }
+        } else {
+            if (stud_type  == "FacetGrid") {
+                
+                sol_rows <- names(sol_facet$params$rows)
+                sol_cols <- names(sol_facet$params$cols)
+                
+                stud_rows <- names(stud_facet$params$rows)
+                stud_cols <- names(stud_facet$params$cols)
+                
+                #Cols and rows can be interchanged
+                equal <- (setequal(sol_rows, stud_rows) & setequal(sol_cols, stud_cols)) | (setequal(sol_rows, stud_cols) & setequal(sol_cols, stud_rows))  
+                return(list('equal' = equal, 'feedback' = ifelse(equal, "", paste0("Did you make a multipanel plot with rows or columns at least divided by (", paste0(sol_facet$vars(), collapse = ", "), ")?")))) 
+            } else {
+                return(list('equal' = FALSE, `feedback` = "Did you use the facet_grid layer?"))
+            }
+        }
+    } 
 }
 
 test_geom_layer <- function(sol_gg, stud_gg){

--- a/utils-plot.R
+++ b/utils-plot.R
@@ -44,7 +44,7 @@ test_facet_layer <- function(sol_facet, stud_facet, ignore_facet_type = TRUE) {
                 stud_cols <- names(stud_facet$params$cols)
                 
                 #Cols and rows can be interchanged
-                equal <- (setequal(sol_rows, stud_rows) & setequal(sol_cols, stud_cols)) | (setequal(sol_rows, stud_cols) & setequal(sol_cols, stud_rows))  
+                equal <- (setequal(sol_rows, stud_rows) && setequal(sol_cols, stud_cols)) || (setequal(sol_rows, stud_cols) && setequal(sol_cols, stud_rows))  
                 return(list('equal' = equal, 'feedback' = ifelse(equal, "", paste0("Did you make a multipanel plot with rows or columns at least divided by (", paste0(sol_facet$vars(), collapse = ", "), ")?")))) 
             } else {
                 return(list('equal' = FALSE, `feedback` = "Did you use the facet_grid layer?"))

--- a/utils-plot.R
+++ b/utils-plot.R
@@ -53,7 +53,6 @@ test_facet_layer <- function(sol_facet, stud_facet, ignore_facet_type = TRUE) {
   } 
 }
 
-
 test_geom_layer <- function(sol_gg, stud_gg){
     sol_layers <- sol_gg$layers
     stud_layers <- stud_gg$layers

--- a/utils-plot.R
+++ b/utils-plot.R
@@ -11,52 +11,48 @@ test_data_layer <- function(sol_data, stud_data) {
     list('equal' = equal, 'feedback' = feedback)
 }
 
-test_facet_layer <- function(sol_facet, stud_facet) {
-    sol_type <- class(sol_facet)[1]
-    stud_type <- class(stud_facet)[1]
-    if(sol_type == "FacetNull"){
-        return(list('equal' = TRUE, 'feedback' = ""))
-    }
-    if(stud_type == "FacetNull"){
-        return(list('equal' = FALSE, 'feedback' = "Did you define a multipanel plot?"))
-    }
-    equal <- FALSE
-    # A facet wrap student code can be matched with a facet grid solution if the solution has 1 row or column and the other way arround
-    if (sol_type == "FacetGrid") {
-        sol_cols <- names(sol_facet$params$cols)
-        sol_rows <- names(sol_facet$params$rows)
-        if (stud_type == "FacetGrid") {
-            stud_cols <- names(stud_facet$params$cols)
-            stud_rows <- names(stud_facet$params$rows)
-            equal <- (length(intersect(sol_cols, stud_cols)) >= length(sol_cols) && 
-                      length(intersect(sol_rows, stud_rows)) >= length(sol_rows))||
-                     (length(intersect(sol_rows, stud_cols)) >= length(sol_rows) && 
-                      length(intersect(sol_cols, stud_rows)) >= length(sol_cols))
-        } else if (stud_type == "FacetWrap" && (length(sol_cols) == 0 || length(sol_rows) == 0)){
-            stud_facets <- names(stud_facet$params$facets)
-            equal <- length(intersect(sol_cols, stud_facets)) >= length(sol_cols)||
-                     length(intersect(sol_rows, stud_facets)) >= length(sol_rows)
-        }
-        if(length(sol_cols) == 0 || length(sol_rows) == 0){
-            return(list('equal' = equal, 'feedback' = paste0("Did you make a multipanel plot with rows or columns at least divided by (", c(sol_rows, sol_cols), ")?")))
-        } else {
-            return(list('equal' = equal, 'feedback' = paste0("Did you make a multipanel plot with rows and columns respectively divided by (", sol_rows, "), (", sol_cols, ") or the other way arround?")))
-        }
+test_facet_layer <- function(sol_facet, stud_facet, ignore_facet_type = TRUE) {
+  sol_type <- class(sol_facet)[1]
+  stud_type <- class(stud_facet)[1]
+  
+  if (sol_type == "FacetNull") {
+    return(list('equal' = TRUE, 'feedback' = ""))
+  }
+  if (stud_type == "FacetNull") {
+    return(list('equal' = FALSE, 'feedback' = "Did you define a multipanel plot?"))
+  }
+  equal <- FALSE
+  
+  if (ignore_facet_type) {
+    equal <- setequal(sol_facet$vars(), stud_facet$vars())
+    return(list('equal' = equal, 'feedback' = ifelse(equal, "", paste0("Did you make a multipanel plot with rows or columns at least divided by (", paste0(sol_facet$vars(), collapse = ", "), ")?")))) 
+  } else {
+    if (sol_type == "FacetWrap") {
+      if (stud_type  == "FacetWrap") {
+        equal <- setequal(sol_facet$vars(), stud_facet$vars())
+        return(list('equal' = equal, 'feedback' = ifelse(equal, "", paste0("Did you make a multipanel plot with rows or columns at least divided by (", paste0(sol_facet$vars(), collapse = ", "), ")?")))) 
+      } else {
+        return(list('equal' = FALSE, `feedback` = "Did you use the facet_wrap layer?"))
+      }
+    } else {
+      if (stud_type  == "FacetGrid") {
         
-    } else if (sol_type == "FacetWrap"){
-        sol_facets <- names(sol_facet$params$facets)
-        if (stud_type == "FacetGrid") {
-            stud_cols <- names(stud_facet$params$cols)
-            stud_rows <- names(stud_facet$params$rows)
-            equal <- length(intersect(sol_facets, stud_cols)) >= length(sol_facets)||
-                     length(intersect(sol_facets, stud_rows)) >= length(sol_facets)
-        } else if (stud_type == "FacetWrap") {
-            stud_facets <- names(stud_facet$params$facets)
-            equal <- length(intersect(sol_facets, stud_facets)) >= length(sol_facets)
-        }
-        return(list('equal' = equal, 'feedback' = ifelse(equal, "", paste0("Did you make a multipanel plot with rows or columns at least divided by (", sol_facets, ")?")))) 
+        sol_rows <- names(sol_facet$params$rows)
+        sol_cols <- names(sol_facet$params$cols)
+        
+        stud_rows <- names(stud_facet$params$rows)
+        stud_cols <- names(stud_facet$params$cols)
+        
+        #Cols and rows can be interchanged
+        equal <- (setequal(sol_rows, stud_rows) & setequal(sol_cols, stud_cols)) | (setequal(sol_rows, stud_cols) & setequal(sol_cols, stud_rows))  
+        return(list('equal' = equal, 'feedback' = ifelse(equal, "", paste0("Did you make a multipanel plot with rows or columns at least divided by (", paste0(sol_facet$vars(), collapse = ", "), ")?")))) 
+      } else {
+        return(list('equal' = FALSE, `feedback` = "Did you use the facet_grid layer?"))
+      }
     }
+  } 
 }
+
 
 test_geom_layer <- function(sol_gg, stud_gg){
     sol_layers <- sol_gg$layers


### PR DESCRIPTION
- Fixed bug in test_facet_layer where TRUE is returned when a student uses more variables in the facetting than required.

- Add ability to check the facet_type as facet_grid can return better graphs when faceting multiple variables. Default is FALSE as in most cases it won't matter but in more advanced graphs it will make a difference.

- README updated for the new `ignore_facet_type` argument