### PR TITLE
Increase default memory limit for R exercises to 200MB

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
     "judge": "R",
-    "image": "dodona-r"
+    "image": "dodona-r",
+    "memory_limit": 200000000
 }


### PR DESCRIPTION
(From the Dodona default of 100MB)