### PR TITLE
Make ast comparison handle non-scalar values

### DIFF
--- a/utils-ast.R
+++ b/utils-ast.R
@@ -5,7 +5,7 @@ is_function_used_in_var <- function(func_name, var_paths, var, main_code) {
 }
 
 is_function_used <- function(func_name, var_paths, sub_tree_root, main_code) {
-    if (sub_tree_root == "") {
+    if (isTRUE(all.equal(sub_tree_root, sym("")))) {
         return(FALSE)
     }
     switch(expr_type(sub_tree_root),


### PR DESCRIPTION
This was a problem introduced by #83 (and I made sure the issue that #83 fixed is still fixed).